### PR TITLE
Update Nginx configuration for PHP handling

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -9,6 +9,9 @@ server {
     index index.html index.htm index.php;
     charset utf-8;
 
+    absolute_redirect off;
+    port_in_redirect off;
+
     location / {
         try_files $uri $uri/ /index.php?$query_string;
     }
@@ -20,6 +23,7 @@ server {
     client_body_timeout 120s;
     sendfile off;
     location ~ \.php$ {
+        try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/home/container/tmp/php-fpm.sock;
         fastcgi_index index.php;
@@ -27,7 +31,7 @@ server {
         fastcgi_param PHP_VALUE "upload_max_filesize = 100M \n post_max_size=100M";
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param HTTP_PROXY "";
-        fastcgi_intercept_errors off;
+        fastcgi_intercept_errors on;
         fastcgi_buffer_size 16k;
         fastcgi_buffers 4 16k;
         fastcgi_connect_timeout 300;

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -23,8 +23,8 @@ server {
     client_body_timeout 120s;
     sendfile off;
     location ~ \.php$ {
-        try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        try_files $fastcgi_script_name =404;
         fastcgi_pass unix:/home/container/tmp/php-fpm.sock;
         fastcgi_index index.php;
         include fastcgi_params;


### PR DESCRIPTION
Fixes https://github.com/Ym0T/pterodactyl-nginx-egg/issues/39 and allows NGINX to serve 404 pages again.