### PR TITLE
Update NGINX installation from v1.22.1 to 1.29.8 + QOL

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,6 +1,7 @@
 name: Docker
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '24 9 * * *'
   push:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,7 +1,6 @@
 name: Docker
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: '24 9 * * *'
   push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,15 @@ RUN apt-get update && apt-get install -y \
         ca-certificates \
         wget \
         curl \
-        nginx \
+        gnupg2 \
+        debian-archive-keyring \
         unzip \
         certbot \
+    && curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/share/keyrings/nginx-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] https://nginx.org/packages/mainline/debian bookworm nginx" > /etc/apt/sources.list.d/nginx.list \
+    && printf "Package: *\nPin: origin nginx.org\nPin: release o=nginx\nPin-Priority: 900\n" > /etc/apt/preferences.d/99nginx \
+    && apt-get update \
+    && apt-get install -y nginx \
     && ARCH=$(uname -m) \
     && if [ "$ARCH" = "x86_64" ]; then \
         wget -O /tmp/cloudflared.deb https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64.deb; \

--- a/modules/nginx/start.sh
+++ b/modules/nginx/start.sh
@@ -59,4 +59,4 @@ echo -e "\033[1;36mSee the LICENSE file for details.\033[0m"
 echo -e "\033[0;34m───────────────────────────────────────────────\033[0m"
 
 # Start NGINX
-nginx -c "$NGINX_CONF" -p "$NGINX_PREFIX"
+nginx -c "$NGINX_CONF" -p "$NGINX_PREFIX" -e /dev/stderr

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -6,6 +6,10 @@ server {
     # access_log /home/container/logs/naccess.log;
     # error_log  /home/container/logs/nerror.log error;
 
+    set_real_ip_from 172.18.0.0/16;
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
     root /home/container/www;
     index index.html index.htm index.php;
     charset utf-8;

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -2,8 +2,9 @@ server {
     listen 80;
     server_name "";
 
-    access_log /home/container/logs/naccess.log;
-    error_log  /home/container/logs/nerror.log error;
+    # Commented out due to this overriding existing configuration already set in nginx/nginx.conf
+    # access_log /home/container/logs/naccess.log;
+    # error_log  /home/container/logs/nerror.log error;
 
     root /home/container/www;
     index index.html index.htm index.php;

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -6,13 +6,16 @@ server {
     # access_log /home/container/logs/naccess.log;
     # error_log  /home/container/logs/nerror.log error;
 
-    set_real_ip_from 172.18.0.0/16;
-    real_ip_header X-Forwarded-For;
+    set_real_ip_from 127.0.0.1;
+    real_ip_header CF-Connecting-IP;
     real_ip_recursive on;
 
     root /home/container/www;
     index index.html index.htm index.php;
     charset utf-8;
+
+    absolute_redirect off;
+    port_in_redirect off;
 
     location / {
         try_files $uri $uri/ /index.php?$query_string;
@@ -20,19 +23,22 @@ server {
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location = /robots.txt  { access_log off; log_not_found off; }
+
     # allow larger file uploads and longer script runtimes
     client_max_body_size 100m;
     client_body_timeout 120s;
     sendfile off;
+
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        try_files $fastcgi_script_name =404;
         fastcgi_pass unix:/home/container/tmp/php-fpm.sock;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param PHP_VALUE "upload_max_filesize = 100M \n post_max_size=100M";
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param HTTP_PROXY "";
-        fastcgi_intercept_errors off;
+        fastcgi_intercept_errors on;
         fastcgi_buffer_size 16k;
         fastcgi_buffers 4 16k;
         fastcgi_connect_timeout 300;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -46,7 +46,7 @@ http {
     	scgi_temp_path /home/container/tmp;
     	fastcgi_temp_path /home/container/tmp;
 	access_log /home/container/logs/access.log;
-	access_log /dev/stdout;
+	# access_log /dev/stdout; # Console access log works but spammy up to you to decide whether to enable or not
 	error_log /home/container/logs/error.log;
 	error_log /dev/stdout;
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -2,7 +2,7 @@ worker_processes auto;
 pid /home/container/tmp/nginx.pid;
 include /home/container/modules-enabled/*.conf;
 error_log /home/container/logs/error.log;
-error_log /dev/stdout;
+error_log /dev/stderr;
 daemon off;
 
 events {
@@ -48,7 +48,7 @@ http {
 	access_log /home/container/logs/access.log;
 	# access_log /dev/stdout; # Console access log works but spammy up to you to decide whether to enable or not
 	error_log /home/container/logs/error.log;
-	error_log /dev/stdout;
+	error_log /dev/stderr;
 
 	##
 	# Gzip Settings


### PR DESCRIPTION
- Following https://nginx.org/en/linux_packages.html#Debian to switch NGINX install from default NGINX install from debian default install to instead use mainline
- Minor change to modules/nginx/start.sh to add `-e /dev/stderr` to startup for better startup error logging.
- Changed nginx/conf.d/default.conf to include cloudflare realip. Additionally commented out logging configured in that file due to it overriding what is configured in nginx/nginx.conf already I am unsure if you would prefer just removing the configuration from nginx/conf.d/default.conf instead of commenting it out.
- Additional minor changes to nginx/nginx.conf to better align container logging. Both `/dev/stderr` and `/dev/stdout` work in pterodactyl due to it merging both into the same console output.

I have tested these changes via ghcr.io/frerduro/pterodactyl-nginx-egg:8.5-latest and have not found any issues so far.