### PR TITLE
fix for bug causing a crash twice every hour, at minutes :08 and :09

### DIFF
--- a/modules/cron/cron-engine.sh
+++ b/modules/cron/cron-engine.sh
@@ -83,5 +83,5 @@ while true; do
   fi
   
   # Sleep until next minute
-  sleep $((60 - $(date '+%S')))
+  sleep $((60 - 10#$(date '+%S')))
 done


### PR DESCRIPTION
The crash happens twice every hour, at minutes :08 and :09. Bash treats numbers with leading zeros as octal — 08 and 09 are invalid octal digits, so $((60 - 09)) throws a fatal error and kills the whole cron engine daemon.